### PR TITLE
fix(ci): Fix release workflow and add macos-arm64 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
             arch: arm64
           - os: macos-latest
             arch: x64
+          - os: macos-latest
+            arch: arm64
 
     steps:
       - name: Checkout code
@@ -70,6 +72,8 @@ jobs:
     name: Create Release
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
- Adds `permissions: contents: write` to the release job to allow the `softprops/action-gh-release` action to upload artifacts to the release. This fixes the "Resource not accessible by integration" error.
- Adds `macos-latest` with `arm64` to the build matrix to enable building for Apple Silicon Macs.