### PR TITLE
Fixed urllib.error.URLError

### DIFF
--- a/dl-kp.py
+++ b/dl-kp.py
@@ -4,7 +4,11 @@ import shutil
 import subprocess
 import configparser
 
+import ssl
+
 import yaml
+
+ssl._create_default_https_context = ssl._create_unverified_context
 
 from utils.Config import Config
 from utils.DownloadError import DownloadError


### PR DESCRIPTION
This issue is caused by the Python environment failing to validate the server's SSL certificate.

The change disables SSL certificate validation at the global level for the application by adding a monkey-patch for the ssl module in `dl-kp.py`. This is a common solution for problems like this, especially in command-line utilities where certificate validation may not be critical.